### PR TITLE
Style changes to keep featured image in center

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -250,6 +250,9 @@ article img {
 .blog-post {
 	.featured-image {
 		border-radius: 12px;
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }
 // Buttons 


### PR DESCRIPTION
Style changes to keep small size width featured images in center, set left and right margin to auto, and make it into a block element.